### PR TITLE
Fix: Detect background light and other properties not in SSDP response

### DIFF
--- a/YeelightDevice/module.php
+++ b/YeelightDevice/module.php
@@ -1163,6 +1163,23 @@ class YeelightDevice extends IPSModule
             }
             $this->ConnectionState = self::isConnected;
             $this->SetStatus(IS_ACTIVE);
+
+            // Detect additional properties not in SSDP response (e.g. bg_* for background light)
+            // Query all known properties from device and add those that return valid values
+            $YeelightData = new \Yeelight\YeelightRPC_Data();
+            $allProperties = array_keys(self::$DataPoints);
+            $YeelightData->get_prop($allProperties);
+            $Result = $this->Send($YeelightData);
+            if ($Result !== false) {
+                $props = $this->Propertys;
+                foreach ($allProperties as $Index => $Property) {
+                    if ($Result[$Index] !== '' && !in_array($Property, $props)) {
+                        $props[] = $Property;
+                    }
+                }
+                $this->Propertys = $props;
+            }
+
             $this->LogMessage('Propertys read:' . implode(' ', $this->Propertys), KL_DEBUG);
             $this->RequestState();
             $this->unlock('IOChangeState');


### PR DESCRIPTION
# Background Light Properties fehlen bei Yeelight Ceiling 10

## Problem

Bei meinem Yeelight Ceiling 10 fehlen Background Light Variablen im WebFront. Nur Main Light wird angezeigt.

## Debugging

Die Instanz zeigte Fehlermeldung: "Fähigkeiten des Gerät konnten nicht ermittelt werden. Es muss Port 1983 (UDP) ankommend an IPS weitergeleitet werden."

Hab UDP-Traffic mit tcpdump geprüft - SSDP Response kommt an, enthält `bg_set_*` Capabilities. Netzwerk funktioniert (macvlan).

Mit `get_prop` direkt getestet:
```json
{"method":"get_prop","params":["bg_power","bg_bright","bg_ct"]}
→ {"result":["off","100","3500"]}
```
Das Gerät liefert alle bg_* Properties zurück.

## Ursache

**Original-Code-Verhalten:**

1. SSDP Discovery → extrahiert Properties aus Response (nur Main Light)
2. Wartet auf Events vom Gerät: `{"method":"props","params":{"bg_power":"on"}}`
3. Erstellt Variablen automatisch wenn Events eintreffen

**Problem:** Events kommen nicht (immer/zuverlässig). Properties die nicht im SSDP Response stehen und keine Events bekommen werden nie abgefragt → Variablen fehlen dauerhaft.

## Fix

Aktives Abfragen statt passives Warten: Nach SSDP Discovery alle Properties aus `self::$DataPoints` via `get_prop` beim Gerät abfragen. Properties mit Werten zur Liste hinzufügen → `RequestState()` fragt sie zuverlässig ab.

## Ergebnis

Ceiling 10: 7 → 17 Properties (bg_power, bg_bright, bg_ct, bg_rgb, bg_hue, bg_sat, bg_lmode, bg_flowing, nl_br, flowing)