### PR TITLE
Fix: Port 1983 UDP Fehler beim Hinzufügen neuer Geräte

### DIFF
--- a/YeelightDevice/module.php
+++ b/YeelightDevice/module.php
@@ -1007,7 +1007,7 @@ class YeelightDevice extends IPSModuleStrict
         $IOId = $this->IORegisterParent();
 
         if ($IOId > 0) {
-            $this->Host = IPS_GetProperty($this->ParentID, 'Host');
+            $this->Host = IPS_GetProperty($IOId, 'Host');
             $this->SetSummary(IPS_GetProperty($IOId, 'Host'));
             // Wenn Parent aktiv, dann Anmeldung an der Hardware bzw. Datenabgleich starten
             if ($this->HasActiveParent()) {
@@ -1033,6 +1033,10 @@ class YeelightDevice extends IPSModuleStrict
                 return;
             }
             $this->ConnectionState = self::isReconnecting;
+            // Ensure Host is set from Parent before calling GetCapabilities
+            if ($this->ParentID > 0) {
+                $this->Host = IPS_GetProperty($this->ParentID, 'Host');
+            }
             if (!$this->GetCapabilities()) {
                 $this->SetStatus(IS_EBASE + 1);
                 $this->ConnectionState = self::isDisconnected;
@@ -1424,7 +1428,8 @@ class YeelightDevice extends IPSModuleStrict
         while ($i) {
             $ret = @socket_recvfrom($socket, $buf, 2048, 0, $IPAddress, $Port);
             if ($ret === false) {
-                break;
+                $i--;
+                continue;
             }
             if ($ret === 0) {
                 $i--;


### PR DESCRIPTION
# "Port 1983 UDP muss weitergeleitet werden" Fehler beim Hinzufügen neuer Yeelight-Geräte

## Problem

Beim Hinzufügen eines neuen Yeelight-Geräts erscheint folgende Fehlermeldung:

> Fähigkeiten des Gerät konnten nicht ermittelt werden. Es muss Port 1983 (UDP) ankommend an IPS weitergeleitet werden. Bitte Firewall oder NAT Weiterleitung prüfen.

**Dabei kommt UDP aber korrekt an!** Die Instanz bleibt im Fehlerstatus (IS_EBASE + 1) und die Geräte-Fähigkeiten können nicht ermittelt werden.

## Umgebung

- IP-Symcon in Docker Container mit macvlan Netzwerk
- Yeelight Color Bulb (10.11.1.80)
- Modul Version: 2.13
- UDP-Pakete kommen nachweislich an (tcpdump zeigt keine Pakete auf Port 1983 während GetCapabilities läuft)

## Ursache

Nach Code-Analyse wurden **3 Bugs** gefunden, die zusammen dieses Problem verursachen:

### Bug 1: socket_recvfrom Timeout-Handling (Zeile ~1426)

```php
// Aktuell:
if ($ret === false) {
    break;  // ❌ Bricht beim ersten Timeout sofort ab
}

// Sollte sein:
if ($ret === false) {
    $i--;
    continue;  // ✅ Versucht es nochmal
}
```

**Problem:** Die Schleife bricht beim ersten Timeout (100ms) sofort ab, obwohl 10 Versuche vorgesehen sind (= 1 Sekunde Gesamt-Timeout).

### Bug 2: Falsche Variable in RegisterParent (Zeile ~1010)

```php
// Aktuell:
$this->Host = IPS_GetProperty($this->ParentID, 'Host');  // ❌ $this->ParentID
$this->SetSummary(IPS_GetProperty($IOId, 'Host'));       // ✅ $IOId

// Sollte sein:
$this->Host = IPS_GetProperty($IOId, 'Host');  // ✅ $IOId (konsistent)
```

**Problem:** `$this->ParentID` ist zu diesem Zeitpunkt möglicherweise noch nicht gesetzt, während `$IOId` von `IORegisterParent()` zurückgegeben wird und garantiert korrekt ist.

### Bug 3: Host nicht gesetzt in IOChangeState (Zeile ~1036)

```php
// IOChangeState wird VOR RegisterParent aufgerufen wenn:
// - IOMessageSink triggert weil Parent aktiv wird
// - Das passiert BEVOR RegisterParent() jemals läuft
// → $this->Host ist leer
// → GetCapabilities() bricht sofort ab (Zeile 1398: if ($this->Host == '') return false;)

// Fix: Host in IOChangeState setzen
if ($this->ParentID > 0) {
    $this->Host = IPS_GetProperty($this->ParentID, 'Host');
}
```

**Problem:** Beim typischen Workflow (neues Gerät + neuer Client Socket zusammen hinzufügen) wird IOChangeState via IOMessageSink getriggert, BEVOR RegisterParent jemals gelaufen ist. `$this->Host` bleibt leer und GetCapabilities sendet kein Discovery-Paket.

## Wann tritt der Fehler auf?

**Schlägt fehl (ohne Fix):**
- Client Socket und Device-Instanz werden gleichzeitig erstellt ← **Typischer Fall!**
- Socket ist beim ersten ApplyChanges noch nicht aktiv
- Später wird Socket aktiv → IOMessageSink triggert IOChangeState
- Aber: `$this->Host` wurde nie gesetzt → GetCapabilities bricht sofort ab

**Funktioniert (auch ohne Fix):**
- Client Socket existiert bereits und ist aktiv BEVOR die Device-Instanz erstellt wird
- RegisterParent läuft und setzt Host, IOChangeState wird direkt aufgerufen
- Lampe antwortet innerhalb 100ms (Bug 1 schlägt nicht zu)

## Lösung

Alle drei Bugs müssen zusammen gefixt werden:

1. **socket_recvfrom Retry-Logik**: Loop bei Timeout fortsetzen
2. **RegisterParent Variable**: `$IOId` statt `$this->ParentID` verwenden
3. **IOChangeState Host setzen**: Host vom Parent lesen bevor GetCapabilities aufgerufen wird

Patch siehe: `yeelight-fix-port-1983-error.patch`

## Test-Ergebnis

Nach dem Fix:
```
GetCapabilities: Starting for host: 10.11.1.80
GetCapabilities: Socket created successfully
GetCapabilities: Socket bound to 0.0.0.0:1983
GetCapabilities: Sent 83 bytes to 10.11.1.80:1982
GetCapabilities: Received 632 bytes from 10.11.1.80:49154  ← UDP Antwort!
GetCapabilities: Finished receive loop. Capabilities count: 31
```

Instanz-Status: IS_ACTIVE ✅

## Zusätzliche Hinweise

Die Fehlermeldung "Port 1983 UDP muss weitergeleitet werden" ist irreführend, da:
1. Der Port nicht weitergeleitet werden muss (UDP kommt an)
2. Das eigentliche Problem ist dass GetCapabilities mit leerem Host abbricht und daher nie ein Discovery-Paket sendet
3. Kein UDP-Traffic entsteht → keine Antwort → Fehlermeldung erscheint

Eine bessere Fehlermeldung wäre: "Geräte-Fähigkeiten konnten nicht ermittelt werden. Prüfen Sie die Client Socket Konfiguration und ob das Gerät erreichbar ist."
