### PR TITLE
Add configurable ResponseTimeout parameter

### DIFF
--- a/YeelightDevice/form.json
+++ b/YeelightDevice/form.json
@@ -28,6 +28,14 @@
                     "value": 2
                 }
             ]
+        },
+        {
+            "name": "ResponseTimeout",
+            "type": "NumberSpinner",
+            "caption": "Response Timeout (ms)",
+            "minimum": 500,
+            "maximum": 5000,
+            "digits": 0
         }
     ],
     "status": [

--- a/YeelightDevice/module.php
+++ b/YeelightDevice/module.php
@@ -79,6 +79,7 @@ class YeelightDevice extends IPSModuleStrict
         $this->RegisterPropertyBoolean('HUESlider', true);
         $this->RegisterPropertyBoolean('SetSmooth', false);
         $this->RegisterPropertyInteger('Mode', 0);
+        $this->RegisterPropertyInteger('ResponseTimeout', 1000);
         $this->ReplyJSONData = [];
         $this->BufferIN = '';
         $this->Capabilities = [];
@@ -1589,7 +1590,8 @@ class YeelightDevice extends IPSModuleStrict
      */
     private function WaitForResponse($Id): false|\Yeelight\RPC_Data
     {
-        for ($i = 0; $i < 1000; $i++) {
+        $timeout = $this->ReadPropertyInteger('ResponseTimeout');
+        for ($i = 0; $i < $timeout; $i++) {
             $ret = $this->ReplyJSONData;
             if (!array_key_exists(intval($Id), $ret)) {
                 return false;


### PR DESCRIPTION
## Summary

This PR adds a configurable  parameter to the YeelightDevice module, allowing users to adjust the timeout for device responses.

## Changes

- Added  configuration field in  (500-5000ms, default: 1000ms)
- Modified  in  to read timeout from configuration instead of hardcoded 1000ms
- Fully backwards compatible (default behavior unchanged)

## Motivation

Users with slower or unreliable WiFi connections may experience "No answer from Device" errors even though the devices eventually respond. This configurable timeout allows them to increase the response timeout as needed.

## Testing

Tested with Yeelight Ceiling 10 devices on WiFi with varying latency. Increasing timeout from 1000ms to 2000ms eliminated false timeout errors while maintaining responsive behavior.